### PR TITLE
Add Qwen provider client

### DIFF
--- a/rig-core/examples/qwen_streaming.rs
+++ b/rig-core/examples/qwen_streaming.rs
@@ -1,0 +1,29 @@
+use rig::agent::stream_to_stdout;
+use rig::prelude::*;
+use rig::providers::qwen;
+use rig::streaming::StreamingPrompt;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Uncomment tracing for debugging
+    tracing_subscriber::fmt().init();
+
+    // Create streaming agent with a single context prompt
+    let agent = qwen::Client::from_env()
+        .agent(qwen::QWEN_PLUS)
+        .preamble("Be precise and concise.")
+        .temperature(0.5)
+        .build();
+
+    // Stream the response and print chunks as they arrive
+    let mut stream = agent
+        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .await;
+
+    let res = stream_to_stdout(&mut stream).await?;
+
+    println!("Token usage response: {usage:?}", usage = res.usage());
+    println!("Final text response: {message:?}", message = res.response());
+
+    Ok(())
+}

--- a/rig-core/src/providers/mod.rs
+++ b/rig-core/src/providers/mod.rs
@@ -61,6 +61,7 @@ pub mod ollama;
 pub mod openai;
 pub mod openrouter;
 pub mod perplexity;
+pub mod qwen;
 pub mod together;
 pub mod voyageai;
 pub mod xai;

--- a/rig-core/src/providers/qwen.rs
+++ b/rig-core/src/providers/qwen.rs
@@ -1,0 +1,376 @@
+//! Qwen API client and Rig integration
+//!
+//! # Example
+//! ```
+//! use rig::providers::qwen;
+//!
+//! let client = qwen::Client::new("YOUR_API_KEY");
+//!
+//! let qwen_chat = client.completion_model(qwen::QWEN_PLUS);
+//! ```
+
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
+use crate::json_utils::merge;
+use crate::providers::openai::send_compatible_streaming_request;
+use crate::streaming::StreamingCompletionResponse;
+use crate::{
+    completion::{self, CompletionError, CompletionRequest},
+    json_utils,
+    providers::openai,
+};
+use crate::{impl_conversion_traits, message};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{Instrument, info_span};
+
+const QWEN_API_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+pub struct ClientBuilder<'a> {
+    api_key: &'a str,
+    base_url: &'a str,
+    http_client: Option<reqwest::Client>,
+}
+
+impl<'a> ClientBuilder<'a> {
+    pub fn new(api_key: &'a str) -> Self {
+        Self {
+            api_key,
+            base_url: QWEN_API_BASE_URL,
+            http_client: None,
+        }
+    }
+
+    pub fn base_url(mut self, base_url: &'a str) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    pub fn custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = Some(client);
+        self
+    }
+
+    pub fn build(self) -> Result<Client, ClientBuilderError> {
+        let http_client = if let Some(http_client) = self.http_client {
+            http_client
+        } else {
+            reqwest::Client::builder().build()?
+        };
+
+        Ok(Client {
+            base_url: self.base_url.to_string(),
+            api_key: self.api_key.to_string(),
+            http_client,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct Client {
+    base_url: String,
+    api_key: String,
+    http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
+}
+
+impl Client {
+    /// Create a new Qwen client builder.
+    ///
+    /// # Example
+    /// ```
+    /// use rig::providers::qwen::{ClientBuilder, self};
+    ///
+    /// let qwen = Client::builder("your-qwen-api-key")
+    ///     .build()
+    ///     .expect("qwen client should build");
+    /// ```
+    pub fn builder(api_key: &str) -> ClientBuilder<'_> {
+        ClientBuilder::new(api_key)
+    }
+
+    /// Create a new Qwen client. For more control, use the `builder` method.
+    ///
+    /// # Panics
+    /// - If the reqwest client cannot be built (if the TLS backend cannot be initialized).
+    pub fn new(api_key: &str) -> Self {
+        Self::builder(api_key)
+            .build()
+            .expect("Qwen client should build")
+    }
+
+    pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.post(url).bearer_auth(&self.api_key)
+    }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
+}
+
+impl ProviderClient for Client {
+    fn from_env() -> Self {
+        let api_key = std::env::var("QWEN_API_KEY").expect("QWEN_API_KEY not set");
+        Self::new(&api_key)
+    }
+
+    fn from_val(input: crate::client::ProviderValue) -> Self {
+        let crate::client::ProviderValue::Simple(api_key) = input else {
+            panic!("Incorrect provider value type")
+        };
+        Self::new(&api_key)
+    }
+}
+
+impl CompletionClient for Client {
+    type CompletionModel = CompletionModel;
+
+    fn completion_model(&self, model: &str) -> CompletionModel {
+        CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            | reqwest::StatusCode::SERVICE_UNAVAILABLE => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl_conversion_traits!(
+    AsEmbeddings,
+    AsTranscription,
+    AsImageGeneration,
+    AsAudioGeneration for Client
+);
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorResponse {
+    error: QwenError,
+}
+
+#[derive(Debug, Deserialize)]
+struct QwenError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ApiResponse<T> {
+    Ok(T),
+    Err(ApiErrorResponse),
+}
+
+impl From<ApiErrorResponse> for CompletionError {
+    fn from(err: ApiErrorResponse) -> Self {
+        CompletionError::ProviderError(err.error.message)
+    }
+}
+
+// ================================================================
+// Qwen Completion API
+// ================================================================
+pub const QWEN_PLUS: &str = "qwen-plus";
+pub const QWEN_MAX: &str = "qwen-max";
+pub const QWEN_TURBO: &str = "qwen-turbo";
+
+#[derive(Clone)]
+pub struct CompletionModel {
+    client: Client,
+    pub model: String,
+}
+
+impl CompletionModel {
+    pub fn new(client: Client, model: &str) -> Self {
+        Self {
+            client,
+            model: model.to_string(),
+        }
+    }
+
+    fn create_completion_request(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<Value, CompletionError> {
+        let mut partial_history = vec![];
+        if let Some(docs) = completion_request.normalized_documents() {
+            partial_history.push(docs);
+        }
+        partial_history.extend(completion_request.chat_history);
+
+        let mut full_history: Vec<openai::Message> = completion_request
+            .preamble
+            .map_or_else(Vec::new, |preamble| {
+                vec![openai::Message::system(&preamble)]
+            });
+
+        full_history.extend(
+            partial_history
+                .into_iter()
+                .map(message::Message::try_into)
+                .collect::<Result<Vec<Vec<openai::Message>>, _>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+        );
+
+        let request = if completion_request.tools.is_empty() {
+            json!({
+                "model": self.model,
+                "messages": full_history,
+                "temperature": completion_request.temperature,
+            })
+        } else {
+            json!({
+                "model": self.model,
+                "messages": full_history,
+                "temperature": completion_request.temperature,
+                "tools": completion_request.tools.into_iter().map(openai::ToolDefinition::from).collect::<Vec<_>>(),
+                "tool_choice": "auto",
+            })
+        };
+
+        let request = if let Some(params) = completion_request.additional_params {
+            json_utils::merge(request, params)
+        } else {
+            request
+        };
+
+        Ok(request)
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    type Response = openai::CompletionResponse;
+    type StreamingResponse = openai::StreamingCompletionResponse;
+
+    #[cfg_attr(feature = "worker", worker::send)]
+    async fn completion(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse<openai::CompletionResponse>, CompletionError> {
+        let preamble = completion_request.preamble.clone();
+        let request = self.create_completion_request(completion_request)?;
+
+        let span = if tracing::Span::current().is_disabled() {
+            info_span!(
+                target: "rig::completions",
+                "chat",
+                gen_ai.operation.name = "chat",
+                gen_ai.provider.name = "qwen",
+                gen_ai.request.model = self.model,
+                gen_ai.system_instructions = preamble,
+                gen_ai.response.id = tracing::field::Empty,
+                gen_ai.response.model = tracing::field::Empty,
+                gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.input.messages = serde_json::to_string(&request.get("messages").unwrap()).unwrap(),
+                gen_ai.output.messages = tracing::field::Empty,
+            )
+        } else {
+            tracing::Span::current()
+        };
+
+        let async_block = async move {
+            let response = self
+                .client
+                .post("/chat/completions")
+                .json(&request)
+                .send()
+                .await?;
+
+            if response.status().is_success() {
+                let t = response.text().await?;
+                tracing::debug!(target: "rig::completions", "Qwen completion response: {t}");
+
+                match serde_json::from_str::<ApiResponse<openai::CompletionResponse>>(&t)? {
+                    ApiResponse::Ok(response) => {
+                        let span = tracing::Span::current();
+                        span.record("gen_ai.response.id", response.id.clone());
+                        span.record("gen_ai.response.model", response.model.clone());
+                        span.record(
+                            "gen_ai.output.messages",
+                            serde_json::to_string(&response.choices).unwrap(),
+                        );
+                        if let Some(ref usage) = response.usage {
+                            span.record("gen_ai.usage.input_tokens", usage.prompt_tokens);
+                            span.record(
+                                "gen_ai.usage.output_tokens",
+                                usage.total_tokens - usage.prompt_tokens,
+                            );
+                        }
+                        response.try_into()
+                    }
+                    ApiResponse::Err(err) => Err(err.into()),
+                }
+            } else {
+                Err(CompletionError::ProviderError(response.text().await?))
+            }
+        };
+
+        async_block.instrument(span).await
+    }
+
+    #[cfg_attr(feature = "worker", worker::send)]
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let preamble = request.preamble.clone();
+        let mut request = self.create_completion_request(request)?;
+
+        let span = if tracing::Span::current().is_disabled() {
+            info_span!(
+                target: "rig::completions",
+                "chat_streaming",
+                gen_ai.operation.name = "chat_streaming",
+                gen_ai.provider.name = "qwen",
+                gen_ai.request.model = self.model,
+                gen_ai.system_instructions = preamble,
+                gen_ai.response.id = tracing::field::Empty,
+                gen_ai.response.model = tracing::field::Empty,
+                gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.input.messages = serde_json::to_string(&request.get("messages").unwrap()).unwrap(),
+                gen_ai.output.messages = tracing::field::Empty,
+            )
+        } else {
+            tracing::Span::current()
+        };
+
+        request = merge(
+            request,
+            json!({"stream": true, "stream_options": {"include_usage": true}}),
+        );
+
+        let builder = self.client.post("/chat/completions").json(&request);
+
+        send_compatible_streaming_request(builder)
+            .instrument(span)
+            .await
+    }
+}

--- a/rig-core/src/providers/qwen.rs
+++ b/rig-core/src/providers/qwen.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{Instrument, info_span};
 
-const QWEN_API_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+const QWEN_API_BASE_URL: &str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 
 pub struct ClientBuilder<'a> {
     api_key: &'a str,
@@ -109,13 +109,19 @@ impl Client {
             .expect("Qwen client should build")
     }
 
+    fn build_url(&self, path: &str) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        let path = path.trim_start_matches('/');
+        format!("{base}/{path}")
+    }
+
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
-        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        let url = self.build_url(path);
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
 
     pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
-        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        let url = self.build_url(path);
         self.http_client.get(url).bearer_auth(&self.api_key)
     }
 }


### PR DESCRIPTION
## Summary
- add a Qwen provider client backed by the DashScope-compatible API
- expose the new client from the providers module for downstream use

## Testing
- cargo check -p rig-core

------
https://chatgpt.com/codex/tasks/task_e_68d8a64eb51c83269ffccb94dbdbbf4e